### PR TITLE
Fix two XXE vulnerabilities

### DIFF
--- a/src/main/java/de/rub/nds/burp/espresso/gui/attacker/saml/UISigWrapAttack.java
+++ b/src/main/java/de/rub/nds/burp/espresso/gui/attacker/saml/UISigWrapAttack.java
@@ -23,6 +23,7 @@ import de.rub.nds.burp.utilities.Logging;
 import de.rub.nds.burp.utilities.listeners.AbstractCodeEvent;
 import de.rub.nds.burp.utilities.listeners.CodeListenerController;
 import de.rub.nds.burp.utilities.listeners.saml.SamlCodeEvent;
+import de.rub.nds.burp.utilities.XMLHelper;
 import java.util.List;
 import javax.swing.DefaultComboBoxModel;
 import org.w3c.dom.Document;
@@ -328,13 +329,9 @@ public class UISigWrapAttack extends javax.swing.JPanel implements IAttack {
         payloadValue.setText(code);
         
         Document doc;
-        try {
-            doc = DomUtilities.stringToDom(code);
-            signatureManager = new SignatureManager();
-            signatureManager.setDocument(doc);
-        } catch (SAXException ex) {
-            Logging.getInstance().log(getClass(), ex);
-        }
+        doc = XMLHelper.stringToDom(code);
+        signatureManager = new SignatureManager();
+        signatureManager.setDocument(doc);
         
         //Initialize the Payload JCombobox
         List<Payload> payloadList = signatureManager.getPayloads();

--- a/src/main/java/de/rub/nds/burp/utilities/XMLHelper.java
+++ b/src/main/java/de/rub/nds/burp/utilities/XMLHelper.java
@@ -19,15 +19,25 @@
 package de.rub.nds.burp.utilities;
 
 
+import java.io.IOException;
 import java.io.StringReader;
 import java.io.StringWriter;
 
+import javax.xml.parsers.DocumentBuilder;
+import javax.xml.parsers.DocumentBuilderFactory;
+import javax.xml.parsers.ParserConfigurationException;
 import javax.xml.transform.OutputKeys;
 import javax.xml.transform.Source;
 import javax.xml.transform.Transformer;
 import javax.xml.transform.TransformerException;
 import javax.xml.transform.TransformerFactory;
 import javax.xml.transform.stream.*;
+import javax.xml.XMLConstants;
+
+import org.xml.sax.SAXException;
+import org.xml.sax.InputSource;
+
+import org.w3c.dom.Document;
 /**
  * Help pretty print XML content
  * @author Tim Guenther
@@ -49,7 +59,8 @@ public abstract class XMLHelper {
             StringWriter stringWriter = new StringWriter();
             StreamResult xmlOutput = new StreamResult(stringWriter);
             TransformerFactory transformerFactory = TransformerFactory.newInstance();
-            Transformer transformer = transformerFactory.newTransformer(); 
+            transformerFactory.setFeature(XMLConstants.FEATURE_SECURE_PROCESSING, true);
+            Transformer transformer = transformerFactory.newTransformer();
             transformer.setOutputProperty(OutputKeys.ENCODING, "UTF-8");
             transformer.setOutputProperty(OutputKeys.OMIT_XML_DECLARATION, "yes");
             transformer.setOutputProperty(OutputKeys.INDENT, "yes");
@@ -59,6 +70,21 @@ public abstract class XMLHelper {
         } catch (IllegalArgumentException | TransformerException e) {
             Logging.getInstance().log(XMLHelper.class, e);
             return input;
+        }
+    }
+
+    public static Document stringToDom (String xmlString) {
+        try {
+            InputSource input = new InputSource(new StringReader(xmlString));
+            DocumentBuilderFactory documentFactory = DocumentBuilderFactory.newInstance();
+            documentFactory.setNamespaceAware(true);
+            documentFactory.setFeature(XMLConstants.FEATURE_SECURE_PROCESSING, true);
+            DocumentBuilder builder = documentFactory.newDocumentBuilder();
+            Document dom = builder.parse(input);
+            return dom;
+        } catch (ParserConfigurationException | SAXException | IOException e) {
+            Logging.getInstance().log(XMLHelper.class, e);
+            return null;
         }
     }
 }


### PR DESCRIPTION
This pull request fixes https://github.com/RUB-NDS/BurpSSOExtension/issues/4.
There were two different XXE-vulnerabilities (afaik) that this commit fixes:

The first one was in [XMLHelper format()](https://github.com/RUB-NDS/BurpSSOExtension/blob/master/src/main/java/de/rub/nds/burp/utilities/XMLHelper.java#L46) which required a single line fix.

The second one is in [SoapUtils of the WS-Attacker project](https://github.com/RUB-NDS/WS-Attacker/blob/5c4c80aefb5024f5220b5ba45c003490b2a3ad4d/framework/src/main/java/wsattacker/util/SoapUtilities.java#L146). I added a simplified version of the vulnerable function to XMLHelper of this project and fixed the vuln there because it was pretty easy to do like that.

I also did some testing and am fairly certain that this commit doesn't break anything. However someone who is more familiar with the plugin should probably test all functionalities.

**TODO:** The stringToDom must be fixed also on the WS-Attacker project and the project should be checked for similar vulnerabilities in rest of the code. I'll try to arrange some time for that.